### PR TITLE
Add with agent skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,9 +42,15 @@ npx vite-plugin-useclassy init --language react
 
 # Svelte
 npx vite-plugin-useclassy init --language svelte
+
+# Also install the AI agent skill (Cursor, Codex, Copilot + AGENTS.md)
+npx vite-plugin-useclassy init --with-skills
+
+# Claude Code users: also copy into .claude/skills
+npx vite-plugin-useclassy init --with-skills --with-claude
 ```
 
-Add **`--dry-run`** to any init command to print the planned file changes without modifying your repo (for example `npx vite-plugin-useclassy init --language react --dry-run`).
+Add **`--dry-run`** to any init command to print the planned file changes without modifying your repo (for example `npx vite-plugin-useclassy init --language react --dry-run`). Use **`--force`** with `--with-skills` to overwrite skill/rule files that differ from the packaged templates.
 
 If detection fails or your config is non-standard, use the manual steps below.
 
@@ -262,18 +268,43 @@ For Vue-only projects you can omit the `className` entries. Running `npx vite-pl
 
 ## AI-assisted setup
 
+### Agent skill (recommended)
+
+Install an [Agent Skill](https://agentskills.io) that teaches AI coding agents how to write and refactor UseClassy markup:
+
+```bash
+npx vite-plugin-useclassy init --with-skills
+```
+
+That writes:
+
+| Destination | Read by |
+|-------------|---------|
+| `.agents/skills/useclassy/` | Cursor, Codex, GitHub Copilot |
+| `.cursor/rules/useclassy-*.mdc` | Cursor (glob-scoped setup and authoring rules) |
+| `AGENTS.md` (fenced section) | Windsurf, Aider, Cline, and other AGENTS.md readers |
+
+Claude Code does not read `.agents/skills`. If you use Claude Code, also pass **`--with-claude`** to copy the same skill into `.claude/skills/useclassy/`. That copy is opt-in because Cursor also discovers `.claude/skills` and would otherwise load the skill twice.
+
+The skill is a single portable `SKILL.md` using the standard `name` + `description` frontmatter. Re-running is idempotent: matching files are left alone, the fenced `AGENTS.md` block (`<!-- useclassy:start -->` … `<!-- useclassy:end -->`) is refreshed to the latest template text without touching content outside the markers, and skill/rule files with local edits are **skipped** unless you pass **`--force`**. `--with-cursor` is an alias for `--with-skills`.
+
+The **skill focuses on writing new UseClassy markup and safely refactoring existing Tailwind variant classes** across Vue, React, Svelte, Blade, and HTML. It teaches grouping by modifier, preserving dynamic classes, handling Svelte directives, and avoiding behavior changes from chained modifiers. Installation and Tailwind/Vite wiring stay in the separate setup rule.
+
+Source templates live in [`templates/`](templates/) if you prefer to copy them manually.
+
+### One-shot prompt
+
 Use this prompt in your editor agent when you want a one-shot manual setup (for example if `init` cannot patch your repo):
 
 **Prompt — “Set up UseClassy in this repo”**
 
 1. Install dev dependency: `vite-plugin-useclassy` (use the repo’s package manager: npm, pnpm, or yarn).
-2. Open `vite.config.*`. Add `import useClassy from 'vite-plugin-useclassy'`. In `plugins`, insert `useClassy({ language: '<vue|react|blade|svelte>' })` **before** `@tailwindcss/vite` or other CSS pipeline plugins so it runs early.
+2. Open `vite.config.*`. Add `import useClassy from 'vite-plugin-useclassy'`. In `plugins`, insert `useClassy({ language: '<vue|react|blade|svelte>' })` **before** `@tailwindcss/vite` or other CSS pipeline plugins so it runs early. For Svelte, also place it before `@sveltejs/vite-plugin-svelte`.
 3. **Tailwind v4** (project uses `@import "tailwindcss"` and typically `@tailwindcss/vite`): In the main CSS entry that imports Tailwind, add an `@source` line pointing at the generated manifest. Default manifest path is `.classy/output.classy.html` from the project root; the `@source` path must be **relative to that CSS file**. If `useClassy` uses custom `outputDir` / `outputFileName`, use those instead.
 4. **Tailwind v3** (`tailwind.config.*`): Add `".classy/output.classy.html"` (or `./.classy/output.classy.html` as appropriate) to the `content` array without removing existing entries.
 5. **VS Code**: In `.vscode/settings.json` (merge, do not wipe), set or extend `tailwindCSS.classAttributes` to include `"class:[\\w:-]*"`. For React, also add `"className:[\\w:-]*"`.
 6. Run `dev` once so `.classy/output.classy.html` is generated; confirm Tailwind includes a class that only appears on a `class:hover` or `className:hover` attribute.
-
-A **Cursor rule template** you can copy into an app repo lives at [`templates/useclassy-setup.cursor-rule.mdc`](templates/useclassy-setup.cursor-rule.mdc).
+7. Optionally run `npx vite-plugin-useclassy init --with-skills` (or copy the templates above) so agents keep using UseClassy modifier attributes when editing UI.
 
 ## Debugging
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -14,8 +14,16 @@ Usage:
 
 Options:
   --language <vue|react|blade|svelte>   Framework language for useClassy (default: vue)
+  --with-skills                    Install the UseClassy agent skill (.agents/skills),
+                                   Cursor rules, and an AGENTS.md section
+  --with-claude                    With --with-skills: also copy the skill to
+                                   .claude/skills for Claude Code
+  --force                          Overwrite skill/rule files that differ from templates
   --dry-run                        Print actions without writing files
   -h, --help                       Show this message
+
+Notes:
+  --with-cursor is an alias for --with-skills.
 `)
 }
 
@@ -23,10 +31,16 @@ function parseArgs(argv: string[]): {
   cmd: string | null
   language: InitLanguage
   dryRun: boolean
+  withSkills: boolean
+  withClaude: boolean
+  force: boolean
 } {
   const rest = argv.slice(2)
   let language: InitLanguage = 'vue'
   let dryRun = false
+  let withSkills = false
+  let withClaude = false
+  let force = false
   let cmd: string | null = null
 
   for (let i = 0; i < rest.length; i++) {
@@ -38,6 +52,18 @@ function parseArgs(argv: string[]): {
     }
     if (arg === '--dry-run') {
       dryRun = true
+      continue
+    }
+    if (arg === '--with-skills' || arg === '--with-cursor') {
+      withSkills = true
+      continue
+    }
+    if (arg === '--with-claude') {
+      withClaude = true
+      continue
+    }
+    if (arg === '--force') {
+      force = true
       continue
     }
     if (arg === '--language' || arg === '-l') {
@@ -54,7 +80,7 @@ function parseArgs(argv: string[]): {
     }
   }
 
-  return { cmd, language, dryRun }
+  return { cmd, language, dryRun, withSkills, withClaude, force }
 }
 
 function exitWithHelp(code: number): never {
@@ -63,7 +89,14 @@ function exitWithHelp(code: number): never {
 }
 
 function main(): void {
-  const { cmd, language, dryRun } = parseArgs(process.argv)
+  const {
+    cmd,
+    language,
+    dryRun,
+    withSkills,
+    withClaude,
+    force,
+  } = parseArgs(process.argv)
 
   if (cmd !== 'init') {
     if (cmd !== null)
@@ -71,7 +104,19 @@ function main(): void {
     exitWithHelp(1)
   }
 
-  const result = runInitSetup({ cwd: process.cwd(), language, dryRun })
+  if (withClaude && !withSkills) {
+    console.error('--with-claude requires --with-skills')
+    exitWithHelp(1)
+  }
+
+  const result = runInitSetup({
+    cwd: process.cwd(),
+    language,
+    dryRun,
+    withSkills,
+    withClaude,
+    force,
+  })
 
   for (const line of result.messages)
     console.log(line)

--- a/src/init-setup.ts
+++ b/src/init-setup.ts
@@ -1,5 +1,6 @@
 import fs from 'fs'
 import path from 'path'
+import { fileURLToPath } from 'url'
 
 import {
   getUseClassyTailwindSourceDirective,
@@ -38,6 +39,8 @@ export type FilePatchResult = {
   path: string
   changed: boolean
   error?: string
+  /** True when a differing local file was left alone (use --force to overwrite). */
+  skipped?: boolean
 }
 
 function readPackageJson(cwd: string): Record<string, unknown> | null {
@@ -169,7 +172,274 @@ export interface InitSetupResult {
   viteConfig?: string
   tailwind?: string
   vscodeSettings?: string
+  agentFiles?: string[]
   messages: string[]
+}
+
+const SKILL_NAME = 'useclassy'
+const SKILL_FILES = ['SKILL.md', 'examples.md'] as const
+
+/** Canonical skill location — Cursor, Codex, and Copilot all read this. */
+const AGENTS_SKILL_DIR = path.join('.agents', 'skills', SKILL_NAME)
+
+/**
+ * Claude Code only reads `.claude/skills` and does not see `.agents/skills`.
+ * Opt-in via `--with-claude` so Cursor does not also load a duplicate copy
+ * (Cursor discovers both `.agents/skills` and `.claude/skills`).
+ */
+const CLAUDE_SKILL_DIR = path.join('.claude', 'skills', SKILL_NAME)
+
+/** Cursor-specific glob-scoped rules; other tools use AGENTS.md. */
+const CURSOR_RULE_FILES = [
+  {
+    from: 'useclassy-setup.cursor-rule.mdc',
+    to: path.join('.cursor', 'rules', 'useclassy-setup.mdc'),
+  },
+  {
+    from: 'useclassy-authoring.cursor-rule.mdc',
+    to: path.join('.cursor', 'rules', 'useclassy-authoring.mdc'),
+  },
+] as const
+
+export type InstallAgentOptions = {
+  templatesRoot?: string | null
+  /** Overwrite skill/rule files that differ from the packaged templates. */
+  force?: boolean
+  /** Also copy the skill into `.claude/skills` for Claude Code. */
+  withClaude?: boolean
+}
+
+function agentTemplateFiles(withClaude: boolean): { from: string, to: string }[] {
+  const destinations = withClaude
+    ? [AGENTS_SKILL_DIR, CLAUDE_SKILL_DIR]
+    : [AGENTS_SKILL_DIR]
+
+  const files: { from: string, to: string }[] = []
+
+  for (const dest of destinations) {
+    for (const name of SKILL_FILES) {
+      files.push({
+        from: path.join('useclassy-skill', name),
+        to: path.join(dest, name),
+      })
+    }
+  }
+
+  return [...files, ...CURSOR_RULE_FILES]
+}
+
+const AGENTS_MD_START = '<!-- useclassy:start -->'
+const AGENTS_MD_END = '<!-- useclassy:end -->'
+
+const AGENTS_MD_SECTION = `${AGENTS_MD_START}
+## UseClassy
+
+This project uses \`vite-plugin-useclassy\`. Write Tailwind variants as modifier
+attributes instead of inline variant prefixes:
+
+- Vue, Svelte, Blade, HTML: \`class="rounded px-4" class:hover="bg-blue-500"\`
+- React: \`className="rounded px-4" className:hover="bg-blue-500"\`
+
+Leave dynamic bindings, Vue \`:class\`, and native Svelte \`class:name={cond}\`
+directives unchanged.
+
+Full authoring and refactoring guide: \`.agents/skills/${SKILL_NAME}/SKILL.md\`
+${AGENTS_MD_END}`
+
+/**
+ * Resolve the packaged `templates/` directory (sibling of `dist/` or `src/`).
+ */
+export function resolveTemplatesRoot(
+  fromUrl: string = import.meta.url,
+): string | null {
+  const here = path.dirname(fileURLToPath(fromUrl))
+  const candidates = [
+    path.join(here, '..', 'templates'),
+    path.join(here, 'templates'),
+    path.join(here, '..', '..', 'templates'),
+  ]
+
+  for (const candidate of candidates) {
+    if (fs.existsSync(path.join(candidate, 'useclassy-skill', 'SKILL.md')))
+      return candidate
+  }
+
+  return null
+}
+
+/**
+ * Upserts the UseClassy section in AGENTS.md for agents that only read
+ * project instruction files. Replaces the fenced block when present so
+ * template updates propagate; leaves content outside the markers alone.
+ */
+export function patchAgentsMdContent(content: string): string {
+  const start = content.indexOf(AGENTS_MD_START)
+  if (start !== -1) {
+    const end = content.indexOf(AGENTS_MD_END, start)
+    if (end === -1)
+      return content
+
+    const endInclusive = end + AGENTS_MD_END.length
+    const existing = content.slice(start, endInclusive)
+    if (existing === AGENTS_MD_SECTION)
+      return content
+
+    const before = content.slice(0, start).trimEnd()
+    const after = content.slice(endInclusive).replace(/^\n*/, '')
+
+    if (before.length === 0) {
+      return after.length > 0
+        ? `# AGENTS.md\n\n${AGENTS_MD_SECTION}\n${after}`
+        : `# AGENTS.md\n\n${AGENTS_MD_SECTION}\n`
+    }
+
+    return after.length > 0
+      ? `${before}\n\n${AGENTS_MD_SECTION}\n${after}`
+      : `${before}\n\n${AGENTS_MD_SECTION}\n`
+  }
+
+  const trimmed = content.trimEnd()
+  if (trimmed.length === 0)
+    return `# AGENTS.md\n\n${AGENTS_MD_SECTION}\n`
+
+  return `${trimmed}\n\n${AGENTS_MD_SECTION}\n`
+}
+
+export function patchAgentsMd(cwd: string, dryRun: boolean): FilePatchResult {
+  const file = path.join(cwd, 'AGENTS.md')
+  const original = fs.existsSync(file)
+    ? fs.readFileSync(file, 'utf-8')
+    : ''
+
+  const next = patchAgentsMdContent(original)
+  if (next === original)
+    return { path: file, changed: false }
+
+  if (!dryRun)
+    fs.writeFileSync(file, next, 'utf-8')
+
+  return { path: file, changed: true }
+}
+
+function writeTemplateFile(
+  source: string,
+  dest: string,
+  dryRun: boolean,
+  force: boolean,
+): FilePatchResult {
+  if (!fs.existsSync(source)) {
+    return {
+      path: dest,
+      changed: false,
+      error: `Missing template: ${path.basename(source)}`,
+    }
+  }
+
+  const content = fs.readFileSync(source, 'utf-8')
+  if (fs.existsSync(dest)) {
+    const existing = fs.readFileSync(dest, 'utf-8')
+    if (existing === content)
+      return { path: dest, changed: false }
+
+    if (!force) {
+      return {
+        path: dest,
+        changed: false,
+        skipped: true,
+      }
+    }
+  }
+
+  if (!dryRun) {
+    fs.mkdirSync(path.dirname(dest), { recursive: true })
+    fs.writeFileSync(dest, content, 'utf-8')
+  }
+
+  return { path: dest, changed: true }
+}
+
+export function installAgentResources(
+  cwd: string,
+  dryRun: boolean,
+  options: InstallAgentOptions = {},
+): FilePatchResult[] {
+  const {
+    templatesRoot,
+    force = false,
+    withClaude = false,
+  } = options
+
+  const resolvedRoot = templatesRoot === undefined
+    ? resolveTemplatesRoot()
+    : templatesRoot
+  const root
+    = resolvedRoot
+      && fs.existsSync(path.join(resolvedRoot, 'useclassy-skill', 'SKILL.md'))
+      ? resolvedRoot
+      : null
+
+  const results: FilePatchResult[] = []
+
+  if (!root) {
+    results.push({
+      path: '',
+      changed: false,
+      error:
+        'Could not find package templates/. Reinstall vite-plugin-useclassy or copy templates manually from the README.',
+    })
+  }
+  else {
+    for (const file of agentTemplateFiles(withClaude)) {
+      results.push(
+        writeTemplateFile(
+          path.join(root, file.from),
+          path.join(cwd, file.to),
+          dryRun,
+          force,
+        ),
+      )
+    }
+  }
+
+  // AGENTS.md section is inline and does not depend on packaged templates.
+  results.push(patchAgentsMd(cwd, dryRun))
+
+  return results
+}
+
+function pushAgentMessages(
+  result: InitSetupResult,
+  patches: FilePatchResult[],
+  dryRun: boolean,
+): void {
+  const writeLabel = dryRun ? '[dry-run] Would write' : 'Wrote'
+  const written: string[] = []
+
+  for (const patch of patches) {
+    if (patch.error) {
+      result.messages.push(`Agent skills: ${patch.error}`)
+      continue
+    }
+
+    if (patch.skipped) {
+      result.messages.push(
+        `Agent skills: skipped ${patch.path} (local edits; pass --force to overwrite)`,
+      )
+      continue
+    }
+
+    if (patch.changed) {
+      written.push(patch.path)
+      result.messages.push(`${writeLabel} ${patch.path}`)
+      continue
+    }
+
+    if (patch.path)
+      result.messages.push(`Agent skills: no changes (${patch.path})`)
+  }
+
+  if (written.length > 0)
+    result.agentFiles = written
 }
 
 function ensureUseClassyImport(content: string): string {
@@ -476,8 +746,18 @@ export function runInitSetup(options: {
   cwd: string
   language: InitLanguage
   dryRun: boolean
+  withSkills?: boolean
+  withClaude?: boolean
+  force?: boolean
 }): InitSetupResult {
-  const { cwd, language, dryRun } = options
+  const {
+    cwd,
+    language,
+    dryRun,
+    withSkills = false,
+    withClaude = false,
+    force = false,
+  } = options
   const result: InitSetupResult = { messages: [] }
 
   const flavor = detectTailwindFlavor(cwd)
@@ -498,6 +778,14 @@ export function runInitSetup(options: {
   }
 
   pushVsCodeMessages(result, patchVsCodeSettings(cwd, language, dryRun), dryRun)
+
+  if (withSkills) {
+    pushAgentMessages(
+      result,
+      installAgentResources(cwd, dryRun, { force, withClaude }),
+      dryRun,
+    )
+  }
 
   return result
 }

--- a/src/tests/init-setup.test.ts
+++ b/src/tests/init-setup.test.ts
@@ -5,10 +5,14 @@ import { afterEach, describe, expect, it } from 'vitest'
 
 import {
   detectTailwindFlavor,
+  installAgentResources,
   mergeTailwindClassAttributes,
+  patchAgentsMdContent,
   patchTailwindV3ConfigContent,
   patchTailwindV4Stylesheet,
   patchViteConfigContent,
+  resolveTemplatesRoot,
+  runInitSetup,
 } from '../init-setup'
 
 function tempDir(): string {
@@ -120,5 +124,211 @@ describe('mergeTailwindClassAttributes', () => {
     expect(out).toContain('class')
     expect(out).toContain('class:[\\w:-]*')
     expect(out).not.toContain('className')
+  })
+})
+
+describe('patchAgentsMdContent', () => {
+  it('creates a section when AGENTS.md is missing or empty', () => {
+    const out = patchAgentsMdContent('')
+    expect(out).toContain('# AGENTS.md')
+    expect(out).toContain('<!-- useclassy:start -->')
+    expect(out).toContain('.agents/skills/useclassy/SKILL.md')
+  })
+
+  it('appends without clobbering existing content', () => {
+    const out = patchAgentsMdContent('# AGENTS.md\n\n## Build\n\nRun pnpm dev.\n')
+    expect(out).toContain('## Build')
+    expect(out).toContain('Run pnpm dev.')
+    expect(out).toContain('## UseClassy')
+  })
+
+  it('is idempotent when the fenced section matches', () => {
+    const once = patchAgentsMdContent('# AGENTS.md\n')
+    expect(patchAgentsMdContent(once)).toBe(once)
+  })
+
+  it('refreshes a stale fenced section without touching other content', () => {
+    const stale = `# AGENTS.md
+
+## Build
+
+Run pnpm dev.
+
+<!-- useclassy:start -->
+## UseClassy
+
+old guidance
+<!-- useclassy:end -->
+
+## Deploy
+
+Ship it.
+`
+    const out = patchAgentsMdContent(stale)
+    expect(out).toContain('## Build')
+    expect(out).toContain('Run pnpm dev.')
+    expect(out).toContain('## Deploy')
+    expect(out).toContain('Ship it.')
+    expect(out).toContain('Full authoring and refactoring guide')
+    expect(out).not.toContain('old guidance')
+    expect(patchAgentsMdContent(out)).toBe(out)
+  })
+})
+
+describe('installAgentResources', () => {
+  it('resolves packaged templates from source layout', () => {
+    const root = resolveTemplatesRoot()
+    expect(root).not.toBeNull()
+    expect(fs.existsSync(path.join(root!, 'useclassy-skill', 'SKILL.md'))).toBe(
+      true,
+    )
+  })
+
+  it('installs the skill into .agents/skills (dry-run writes nothing)', () => {
+    const dir = tempDir()
+    fs.writeFileSync(
+      path.join(dir, 'package.json'),
+      JSON.stringify({ name: 'app' }),
+      'utf-8',
+    )
+
+    // 1 skill dir x 2 files + 2 cursor rules + AGENTS.md
+    const dry = installAgentResources(dir, true)
+    expect(dry.every(r => !r.error)).toBe(true)
+    expect(dry.filter(r => r.changed)).toHaveLength(5)
+    expect(
+      fs.existsSync(path.join(dir, '.agents', 'skills', 'useclassy', 'SKILL.md')),
+    ).toBe(false)
+
+    const written = installAgentResources(dir, false)
+    expect(written.filter(r => r.changed)).toHaveLength(5)
+
+    const agentsSkill = path.join(dir, '.agents', 'skills', 'useclassy', 'SKILL.md')
+    const skill = fs.readFileSync(agentsSkill, 'utf-8')
+    expect(skill).toContain('name: useclassy')
+    expect(skill).toContain('## Refactor existing code')
+    expect(skill).not.toContain('## Setup')
+
+    // Default install avoids .claude so Cursor does not load a duplicate skill.
+    expect(fs.existsSync(path.join(dir, '.claude'))).toBe(false)
+    expect(
+      fs.existsSync(path.join(dir, '.agents', 'skills', 'useclassy', 'examples.md')),
+    ).toBe(true)
+
+    expect(
+      fs.existsSync(path.join(dir, '.cursor', 'rules', 'useclassy-setup.mdc')),
+    ).toBe(true)
+    expect(
+      fs.existsSync(
+        path.join(dir, '.cursor', 'rules', 'useclassy-authoring.mdc'),
+      ),
+    ).toBe(true)
+
+    expect(fs.readFileSync(path.join(dir, 'AGENTS.md'), 'utf-8')).toContain(
+      '## UseClassy',
+    )
+
+    const again = installAgentResources(dir, false)
+    expect(again.every(r => !r.changed && !r.error && !r.skipped)).toBe(true)
+  })
+
+  it('copies into .claude/skills only when withClaude is set', () => {
+    const dir = tempDir()
+    const written = installAgentResources(dir, false, { withClaude: true })
+    expect(written.filter(r => r.changed)).toHaveLength(7)
+
+    const agentsSkill = fs.readFileSync(
+      path.join(dir, '.agents', 'skills', 'useclassy', 'SKILL.md'),
+      'utf-8',
+    )
+    const claudeSkill = fs.readFileSync(
+      path.join(dir, '.claude', 'skills', 'useclassy', 'SKILL.md'),
+      'utf-8',
+    )
+    expect(claudeSkill).toBe(agentsSkill)
+  })
+
+  it('skips differing local skill files unless force is set', () => {
+    const dir = tempDir()
+    installAgentResources(dir, false)
+
+    const skillPath = path.join(dir, '.agents', 'skills', 'useclassy', 'SKILL.md')
+    fs.writeFileSync(skillPath, '# customized locally\n', 'utf-8')
+
+    const skipped = installAgentResources(dir, false)
+    const skillResult = skipped.find(r => r.path === skillPath)
+    expect(skillResult?.skipped).toBe(true)
+    expect(skillResult?.changed).toBe(false)
+    expect(fs.readFileSync(skillPath, 'utf-8')).toBe('# customized locally\n')
+
+    const forced = installAgentResources(dir, false, { force: true })
+    expect(forced.find(r => r.path === skillPath)?.changed).toBe(true)
+    expect(fs.readFileSync(skillPath, 'utf-8')).toContain('name: useclassy')
+  })
+
+  it('still writes AGENTS.md when templates are missing', () => {
+    const dir = tempDir()
+    const results = installAgentResources(dir, false, {
+      templatesRoot: path.join(dir, 'missing-templates'),
+    })
+
+    expect(results.some(r => r.error?.includes('Could not find package templates'))).toBe(
+      true,
+    )
+    expect(fs.readFileSync(path.join(dir, 'AGENTS.md'), 'utf-8')).toContain(
+      '## UseClassy',
+    )
+  })
+
+  it('runInitSetup --with-skills installs agent files', () => {
+    const dir = tempDir()
+    fs.writeFileSync(
+      path.join(dir, 'package.json'),
+      JSON.stringify({
+        name: 'app',
+        devDependencies: { '@tailwindcss/vite': '^4.0.0' },
+      }),
+      'utf-8',
+    )
+    fs.writeFileSync(
+      path.join(dir, 'vite.config.ts'),
+      `import { defineConfig } from 'vite'\nexport default defineConfig({ plugins: [] })\n`,
+      'utf-8',
+    )
+    fs.mkdirSync(path.join(dir, 'src'), { recursive: true })
+    fs.writeFileSync(
+      path.join(dir, 'src', 'main.css'),
+      '@import "tailwindcss";\n',
+      'utf-8',
+    )
+
+    const result = runInitSetup({
+      cwd: dir,
+      language: 'vue',
+      dryRun: true,
+      withSkills: true,
+    })
+
+    expect(result.messages.some(m => m.includes('[dry-run] Would write')
+      && m.includes(path.join('.agents', 'skills')))).toBe(true)
+    expect(result.messages.some(m => m.includes(path.join('.claude', 'skills')))).toBe(
+      false,
+    )
+    expect(result.messages.some(m => m.includes('AGENTS.md'))).toBe(true)
+  })
+
+  it('leaves agent files alone without the flag', () => {
+    const dir = tempDir()
+    fs.writeFileSync(
+      path.join(dir, 'package.json'),
+      JSON.stringify({ name: 'app' }),
+      'utf-8',
+    )
+
+    const result = runInitSetup({ cwd: dir, language: 'vue', dryRun: false })
+
+    expect(result.agentFiles).toBeUndefined()
+    expect(fs.existsSync(path.join(dir, '.agents'))).toBe(false)
+    expect(fs.existsSync(path.join(dir, 'AGENTS.md'))).toBe(false)
   })
 })

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -1,0 +1,5 @@
+# Lessons
+
+- When a user asks for an AI skill “for building with” a library, separate installation/setup guidance from code-authoring guidance. Confirm whether the skill should teach setup, authoring, migration, or all three before drafting it.
+- A UseClassy authoring skill must prioritize safe code transformation: migrate static single-modifier Tailwind tokens, preserve dynamic bindings and framework directives, and account for additive chained-modifier behavior.
+- Do not assume Cursor is the only target when shipping agent resources. `SKILL.md` is a portable standard; only the install path is tool-specific. Default to `.agents/skills/` (Cursor, Codex, Copilot), append a fenced `AGENTS.md` section for everything else, and make `.claude/skills/` opt-in — Cursor also loads `.claude/skills`, so installing both duplicates the skill. Name CLI flags for the capability (`--with-skills`), not for one vendor. Skip overwriting locally edited skill files unless `--force`.

--- a/templates/useclassy-authoring.cursor-rule.mdc
+++ b/templates/useclassy-authoring.cursor-rule.mdc
@@ -1,0 +1,33 @@
+---
+description: Write UseClassy modifier attributes and safely refactor existing Tailwind variant classes.
+globs: "**/*.{vue,svelte,tsx,jsx,blade.php,html}"
+---
+
+# UseClassy authoring and refactoring
+
+When this project uses `vite-plugin-useclassy`, write new static Tailwind variants as modifier attributes and migrate existing static variant tokens when behavior is preserved.
+
+## Conversion
+
+```html
+<!-- Before -->
+<button class="rounded px-4 hover:bg-blue-500 hover:text-white sm:px-6">
+
+<!-- After -->
+<button class="rounded px-4" class:hover="bg-blue-500 text-white" class:sm="px-6">
+```
+
+```tsx
+<button className="rounded px-4" className:hover="bg-blue-500" className:focus="ring-2">
+```
+
+## Rules
+
+- Base utilities on `class` / `className`; variants on `class:mod="…"` / `className:mod="…"`.
+- Group static utilities by identical single modifier and remove the prefix from each modifier value.
+- Values must be double-quoted static strings.
+- Leave dynamic expressions, template interpolation, conditional helpers, and Vue `:class` unchanged.
+- **Svelte**: only transform quoted UseClassy modifiers (`class:hover="…"`). Do not rewrite native `class:name={cond}` or `class:name`.
+- Keep arbitrary variants such as `[&>*]:mt-2` and `data-[state=open]:block` in the base string.
+- Chained attributes are additive: `class:sm:hover="underline"` generates `sm:hover:underline`, `sm:underline`, and `hover:underline`. Keep an existing exact chained token in the base string unless all combinations are intended.
+- After refactoring, run formatting and relevant tests/build; verify dynamic classes and rendered states are unchanged.

--- a/templates/useclassy-setup.cursor-rule.mdc
+++ b/templates/useclassy-setup.cursor-rule.mdc
@@ -6,10 +6,10 @@ globs: vite.config.*,tailwind.config.*,**/*.css,.vscode/settings.json
 When adding or fixing UseClassy in this project:
 
 1. Install `vite-plugin-useclassy` as a dev dependency (use this repo’s package manager).
-2. In `vite.config.*`, import `useClassy` from `vite-plugin-useclassy` and add `useClassy({ language: 'vue' | 'react' | 'blade' })` to `plugins` **before** `@tailwindcss/vite` or other CSS plugins.
+2. In `vite.config.*`, import `useClassy` from `vite-plugin-useclassy` and add `useClassy({ language: 'vue' | 'react' | 'blade' | 'svelte' })` to `plugins` **before** `@tailwindcss/vite` or other CSS plugins. For Svelte, also place it **before** `@sveltejs/vite-plugin-svelte`.
 3. **Tailwind v4** (CSS uses `@import "tailwindcss"`): In that stylesheet, add an `@source` line pointing at the generated manifest. Default manifest path is `.classy/output.classy.html` from the project root; the `@source` path must be **relative to the CSS file**. In JavaScript configs you can compute the line with `getUseClassyTailwindSourceDirective(cssAbsolutePath, projectRoot)` from `vite-plugin-useclassy`.
 4. **Tailwind v3**: Add `./.classy/output.classy.html` to `content` in `tailwind.config.*` (or use `getUseClassyTailwindV3ContentEntry()` from the package for the default path).
 5. **VS Code**: Merge `tailwindCSS.classAttributes` to include `class:[\\w:-]*` and, for React, `className:[\\w:-]*`.
 6. Run dev once so `.classy/output.classy.html` is generated.
 
-Prefer `npx vite-plugin-useclassy init` (after installing the package) instead of hand-editing when possible.
+Prefer `npx vite-plugin-useclassy init` (after installing the package) instead of hand-editing when possible. Use `--with-skills` to install the UseClassy authoring skill (`.agents/skills`) plus these Cursor rules. Add `--with-claude` if you also use Claude Code.

--- a/templates/useclassy-skill/SKILL.md
+++ b/templates/useclassy-skill/SKILL.md
@@ -1,0 +1,92 @@
+---
+name: useclassy
+description: >-
+  Write and refactor Vue, React, Svelte, Blade, and HTML markup using
+  vite-plugin-useclassy modifier attributes such as class:hover and
+  className:focus. Use when authoring UI, converting existing Tailwind variant
+  classes to UseClassy, or reviewing and fixing UseClassy markup.
+---
+
+# Authoring with UseClassy
+
+Use UseClassy to separate Tailwind variants from base utilities:
+
+```html
+<!-- Before -->
+<button class="rounded px-4 hover:bg-blue-500 hover:text-white focus:ring-2">
+
+<!-- After -->
+<button
+  class="rounded px-4"
+  class:hover="bg-blue-500 text-white"
+  class:focus="ring-2"
+>
+```
+
+## Syntax
+
+| Language | Base | Modifiers |
+|----------|------|-----------|
+| Vue / Blade | `class="…"` | `class:hover="…"`, `class:sm:hover="…"` |
+| React | `className="…"` | `className:hover="…"` (also accepts `class:…`) |
+| Svelte | `class="…"` | Quoted only: `class:hover="…"` |
+
+Modifier names may contain letters, numbers, `_`, `-`, and `:`. Values must be double-quoted static class strings.
+
+## Refactor existing code
+
+When asked to convert markup to UseClassy:
+
+1. Identify the framework from the file/config; use `className:` for React and `class:` elsewhere.
+2. Inspect each **static** `class` / `className` string.
+3. Keep unprefixed utilities in the base attribute.
+4. Group utilities with the same single modifier and remove that prefix:
+   - `hover:bg-blue-500 hover:text-white` → `class:hover="bg-blue-500 text-white"`
+   - `focus:ring-2 focus:ring-blue-400` → `class:focus="ring-2 ring-blue-400"`
+   - `md:px-6 md:py-3` → `class:md="px-6 py-3"`
+5. Preserve utility order within each group and preserve unrelated attributes/expressions.
+6. Review the result for the exceptions below.
+
+Convert only static tokens that can be represented safely. Do not rewrite:
+
+- Dynamic expressions, template interpolations, conditional class helpers, Vue `:class`, or Svelte directives.
+- Arbitrary variant prefixes such as `[&>*]:mt-2` or `data-[state=open]:block`; their characters are not valid in a UseClassy modifier name.
+- Variant tokens embedded in variables or function calls.
+
+## Chained modifier semantics
+
+UseClassy accepts chained attributes such as `class:sm:hover="underline"`, but it expands the value for the combined chain **and each individual modifier**:
+
+```html
+class:sm:hover="underline"
+<!-- produces sm:hover:underline, sm:underline, and hover:underline -->
+```
+
+Therefore, converting an existing `sm:hover:underline` token to `class:sm:hover="underline"` is **not behavior-preserving** unless those additional `sm:` and `hover:` styles are intended. When preserving behavior:
+
+- Migrate single-modifier tokens automatically.
+- Leave exact chained tokens such as `sm:hover:underline` in the base class string.
+- Use a chained UseClassy attribute only when the requested design intentionally applies all generated combinations.
+
+## Framework rules
+
+- Put base utilities on `class` / `className`.
+- Vue / Blade / HTML: use `class:modifier="…"`.
+- React: prefer `className:modifier="…"` and keep dynamic `className={...}` expressions unchanged.
+- Vue: leave `:class` and other dynamic bindings unchanged.
+- **Svelte**: only quoted UseClassy modifiers transform. Native `class:active={cond}` and `class:active` stay untouched — do not rewrite those.
+- Do not move conditional base utilities into modifier attributes; UseClassy modifiers represent Tailwind variants, not runtime conditions.
+
+## Verification
+
+After a refactor:
+
+1. Confirm every moved utility lost exactly the modifier encoded in its attribute name.
+2. Confirm base and dynamic classes remain intact.
+3. Confirm Svelte native directives remain expressions/directives.
+4. Run the project’s formatter, typecheck, and relevant tests/build.
+5. Inspect transformed output or the rendered UI when chained modifiers or ordering could change behavior.
+
+## More examples
+
+See [examples.md](examples.md).

--- a/templates/useclassy-skill/examples.md
+++ b/templates/useclassy-skill/examples.md
@@ -1,0 +1,133 @@
+# UseClassy refactoring examples
+
+## Vue: group static variants
+
+```html
+<!-- Before -->
+<div
+  class="rounded-lg p-4 bg-white hover:shadow-lg sm:p-6 dark:bg-zinc-900 dark:text-zinc-100"
+  :class="{ active: isActive }"
+>
+
+<!-- After -->
+<div
+  class="rounded-lg p-4 bg-white"
+  class:hover="shadow-lg"
+  class:sm="p-6"
+  class:dark="bg-zinc-900 text-zinc-100"
+  :class="{ active: isActive }"
+>
+```
+
+Leave exact chained variants in the base attribute unless additive chained behavior is wanted:
+
+```html
+<div
+  class="rounded-lg sm:hover:shadow-xl"
+  class:hover="shadow-lg"
+  class:sm="p-6"
+>
+```
+
+Do not alter Vue dynamic bindings:
+
+```html
+<div
+  class="base"
+  :class="{ active: isActive }"
+  class:hover="opacity-90"
+>
+```
+
+## React: preserve expressions
+
+```tsx
+// Before
+<button
+  className={`rounded px-4 hover:bg-blue-600 focus:ring-2 ${active ? 'font-bold' : ''}`}
+>
+  Save
+</button>
+
+// After: only move safely separable static variants.
+<button
+  className={`rounded px-4 ${active ? 'font-bold' : ''}`}
+  className:hover="bg-blue-600"
+  className:focus="ring-2"
+>
+  Save
+</button>
+```
+
+If moving tokens safely would require rewriting expression logic, leave the expression unchanged. UseClassy modifier attributes are not a replacement for `clsx`, `classy`, or conditional expressions.
+
+## Svelte: preserve native directives
+
+```svelte
+<!-- Before -->
+<button
+  class="rounded px-4 hover:bg-emerald-600 hover:text-white"
+  class:loading={isLoading}
+>
+  Submit
+</button>
+
+<!-- After -->
+<button
+  class="rounded px-4"
+  class:hover="bg-emerald-600 text-white"
+  class:loading={isLoading}
+>
+  Submit
+</button>
+```
+
+`class:loading={isLoading}` is native Svelte and must not be converted to a string attribute.
+
+## Blade
+
+```blade
+{{-- Before --}}
+<a
+  href="{{ $url }}"
+  class="font-medium text-zinc-700 hover:text-zinc-900 hover:underline md:text-lg"
+>
+  {{ $label }}
+</a>
+
+{{-- After --}}
+<a
+  href="{{ $url }}"
+  class="font-medium text-zinc-700"
+  class:hover="text-zinc-900 underline"
+  class:md="text-lg"
+>
+  {{ $label }}
+</a>
+```
+
+## Chained modifiers are additive
+
+```html
+<!-- This is intentionally additive, not equivalent to only dark:focus:ring-sky-400 -->
+<input class:dark:focus="ring-sky-400" />
+
+<!-- Generated classes include: -->
+<input class="dark:focus:ring-sky-400 dark:ring-sky-400 focus:ring-sky-400" />
+```
+
+To preserve an existing exact chained variant, keep it in the base string:
+
+```html
+<input class="border dark:focus:ring-sky-400" class:focus="outline-none ring-2" />
+```
+
+## Unsupported arbitrary variant prefix
+
+Keep arbitrary variants in the base attribute because their prefix cannot be used as an attribute name:
+
+```html
+<ul class="space-y-2 [&>*]:rounded" class:hover="bg-zinc-50">
+  ...
+</ul>
+```

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -15,7 +15,7 @@ export default defineConfig({
         `${entryName}.${format === 'es' ? 'js' : 'cjs'}`,
     },
     rollupOptions: {
-      external: ['vite', 'react', 'path', 'fs', 'crypto'],
+      external: ['vite', 'react', 'path', 'fs', 'crypto', 'url', 'node:url', 'node:fs', 'node:path'],
       output: {
         preserveModules: true,
         exports: 'named',


### PR DESCRIPTION
- Added support for installing UseClassy agent skills via `--with-skills` and copying to Claude Code with `--with-claude`.
- Introduced `--force` option to overwrite existing skill files during installation.
- Updated README and CLI documentation to reflect new options and usage.
- Enhanced AGENTS.md management to ensure proper installation and updates of agent resources.
- Added tests for new functionality in agent resource installation and AGENTS.md patching.